### PR TITLE
Change `conda env export method` and linting. 

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -2,32 +2,15 @@ name: esg_codebase
 channels:
   - defaults
 dependencies:
-  - appdirs=1.4.4
-  - attrs=21.2.0
-  - black=19.10b0
-  - ca-certificates=2021.5.25
-  - certifi=2021.5.30
-  - importlib-metadata=3.10.0
-  - libcxx=10.0.0
-  - libffi=3.3
-  - mypy_extensions=0.4.3
-  - ncurses=6.2
-  - openssl=1.1.1k
-  - pathspec=0.7.0
-  - pip=21.1.1
-  - python=3.8.10
-  - readline=8.1
-  - regex=2021.4.4
-  - setuptools=52.0.0
-  - sqlite=3.35.4
-  - tk=8.6.10
-  - toml=0.10.2
-  - typed-ast=1.4.2
-  - typing_extensions=3.7.4.3
   - wheel=0.36.2
-  - xz=5.2.5
-  - zipp=3.4.1
-  - zlib=1.2.11
+  - openssl
+  - python=3.8.10
+  - pip=21.1.1
+  - setuptools=52.0.0
+  - certifi
+  - ca-certificates
+  - sqlite=3.35.4
+  - black
   - pip:
     - altair==4.1.0
     - appnope==0.1.2
@@ -45,14 +28,22 @@ dependencies:
     - chardet==4.0.0
     - chart-studio==1.1.0
     - click==7.1.2
+    - cloudpickle==1.6.0
     - colorama==0.4.4
+    - croniter==0.3.37
+    - dask==2021.6.0
     - decorator==5.0.9
     - defusedxml==0.7.1
+    - distributed==2021.6.0
+    - docker==5.0.0
     - entrypoints==0.3
+    - fsspec==2021.5.0
     - future==0.18.2
     - gitdb==4.0.7
     - gitpython==3.1.17
+    - heapdict==1.0.1
     - idna==2.10
+    - imageio==2.9.0
     - install==1.3.4
     - ipykernel==5.5.5
     - ipython==7.23.1
@@ -67,10 +58,13 @@ dependencies:
     - jupyterlab-pygments==0.1.2
     - jupyterlab-widgets==1.0.0
     - livereload==2.6.3
+    - locket==0.2.1
     - lunr==0.5.8
     - lxml==4.6.3
     - markdown==3.3.4
     - markupsafe==2.0.1
+    - marshmallow==3.12.1
+    - marshmallow-oneofschema==2.1.0
     - matplotlib-inline==0.1.2
     - mistune==0.8.4
     - mkdocs==1.1.2
@@ -78,6 +72,8 @@ dependencies:
     - mkdocs-material==7.1.5
     - mkdocs-material-extensions==1.0.1
     - mkdocstrings==0.15.1
+    - msgpack==1.0.2
+    - natsort==7.1.1
     - nbclient==0.5.3
     - nbconvert==6.0.7
     - nbformat==5.1.3
@@ -89,13 +85,17 @@ dependencies:
     - pandas==1.2.4
     - pandocfilters==1.4.3
     - parso==0.8.2
+    - partd==1.2.0
+    - pendulum==2.1.2
     - pexpect==4.8.0
     - pickleshare==0.7.5
     - pillow==8.2.0
     - plotly==4.14.3
+    - prefect==0.14.21
     - prometheus-client==0.10.1
     - prompt-toolkit==3.0.18
     - protobuf==3.17.0
+    - psutil==5.8.0
     - ptyprocess==0.7.0
     - pyarrow==4.0.0
     - pycparser==2.20
@@ -104,11 +104,14 @@ dependencies:
     - pymdown-extensions==8.2
     - pyparsing==2.4.7
     - pyrsistent==0.17.3
+    - python-box==5.3.0
     - python-dateutil==2.8.1
+    - python-slugify==5.0.2
     - pytickersymbols==1.7.0
     - pytkdocs==0.11.1
     - pytrends==4.7.3
     - pytz==2021.1
+    - pytzdata==2020.1
     - pyyaml==5.4.1
     - pyzmq==22.0.3
     - requests==2.25.1
@@ -117,10 +120,14 @@ dependencies:
     - send2trash==1.5.0
     - six==1.16.0
     - smmap==4.0.0
+    - sortedcontainers==2.4.0
     - soupsieve==2.2.1
     - streamlit==0.82.0
+    - tabulate==0.8.9
+    - tblib==1.7.0
     - terminado==0.10.0
     - testpath==0.5.0
+    - text-unidecode==1.3
     - toolz==0.11.1
     - tornado==6.1
     - tqdm==4.60.0
@@ -131,6 +138,7 @@ dependencies:
     - watchdog==2.1.2
     - wcwidth==0.2.5
     - webencodings==0.5.1
+    - websocket-client==1.0.1
     - widgetsnbextension==3.5.1
     - yahooquery==2.2.15
-prefix: /Users/tiansuyu/anaconda3/envs/esg_codebase
+    - zict==2.0.0

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -2,24 +2,39 @@ name: esg_codebase
 channels:
   - defaults
 dependencies:
-  - ca-certificates=2021.4.13=haa95532_1
-  - certifi=2020.12.5=py38haa95532_0
-  - openssl=1.1.1k=h2bbff1b_0
-  - pip=21.1.1=py38haa95532_0
-  - python=3.8.10=hdbf39b2_7
-  - setuptools=52.0.0=py38haa95532_0
-  - sqlite=3.35.4=h2bbff1b_0
-  - vc=14.2=h21ff451_1
-  - vs2015_runtime=14.27.29016=h5e58377_2
-  - wheel=0.36.2=pyhd3eb1b0_0
-  - wincertstore=0.2=py38_0
+  - appdirs=1.4.4
+  - attrs=21.2.0
+  - black=19.10b0
+  - ca-certificates=2021.5.25
+  - certifi=2021.5.30
+  - importlib-metadata=3.10.0
+  - libcxx=10.0.0
+  - libffi=3.3
+  - mypy_extensions=0.4.3
+  - ncurses=6.2
+  - openssl=1.1.1k
+  - pathspec=0.7.0
+  - pip=21.1.1
+  - python=3.8.10
+  - readline=8.1
+  - regex=2021.4.4
+  - setuptools=52.0.0
+  - sqlite=3.35.4
+  - tk=8.6.10
+  - toml=0.10.2
+  - typed-ast=1.4.2
+  - typing_extensions=3.7.4.3
+  - wheel=0.36.2
+  - xz=5.2.5
+  - zipp=3.4.1
+  - zlib=1.2.11
   - pip:
     - altair==4.1.0
+    - appnope==0.1.2
     - argon2-cffi==20.1.0
     - astor==0.8.1
     - astunparse==1.6.3
     - async-generator==1.10
-    - attrs==21.2.0
     - backcall==0.2.0
     - base58==2.1.0
     - beautifulsoup4==4.9.3
@@ -74,12 +89,14 @@ dependencies:
     - pandas==1.2.4
     - pandocfilters==1.4.3
     - parso==0.8.2
+    - pexpect==4.8.0
     - pickleshare==0.7.5
     - pillow==8.2.0
     - plotly==4.14.3
     - prometheus-client==0.10.1
     - prompt-toolkit==3.0.18
     - protobuf==3.17.0
+    - ptyprocess==0.7.0
     - pyarrow==4.0.0
     - pycparser==2.20
     - pydeck==0.6.2
@@ -88,14 +105,12 @@ dependencies:
     - pyparsing==2.4.7
     - pyrsistent==0.17.3
     - python-dateutil==2.8.1
+    - pytickersymbols==1.7.0
     - pytkdocs==0.11.1
     - pytrends==4.7.3
     - pytz==2021.1
-    - pywin32==300
-    - pywinpty==1.1.1
     - pyyaml==5.4.1
     - pyzmq==22.0.3
-    - regex==2021.4.4
     - requests==2.25.1
     - requests-futures==1.0.0
     - retrying==1.3.3
@@ -106,7 +121,6 @@ dependencies:
     - streamlit==0.82.0
     - terminado==0.10.0
     - testpath==0.5.0
-    - toml==0.10.2
     - toolz==0.11.1
     - tornado==6.1
     - tqdm==4.60.0
@@ -119,4 +133,4 @@ dependencies:
     - webencodings==0.5.1
     - widgetsnbextension==3.5.1
     - yahooquery==2.2.15
-prefix: C:\Users\phili\miniconda3\envs\esg_codebase
+prefix: /Users/tiansuyu/anaconda3/envs/esg_codebase

--- a/conda_env_export.py
+++ b/conda_env_export.py
@@ -1,0 +1,70 @@
+"""
+Export a Conda environment with --from-history, but also append
+Pip-installed dependencies
+
+For `conda_env.yml`, we dont use the following two commands, but this py file instead:
+- `Conda env export --from-history -f conda_env.yaml` does not contain pip installments
+- `Conda env export -f conda_env.yaml` pins dependencies too hard (add conda build number,
+which is os dependent, add os-denpendent libs as well).
+
+This is adopted from https://gist.github.com/gwerbin/dab3cf5f8db07611c6e0aeec177916d8
+
+Example:
+    In root folder of this repo:
+    >> which python # make sure you are in the right virtual env
+    >> python conda_env_export.py
+"""
+
+# TODO currently leave out python and pip, fix this.
+
+import subprocess
+
+from root_logger import logger
+
+logger = logger()
+
+
+def export_env(history_only=False, include_builds=False):
+    """ Capture `conda env export` output """
+    cmd = ["conda", "env", "export"]
+    if history_only:
+        cmd.append("--from-history")
+        if include_builds:
+            raise ValueError('Cannot include build versions with "from history" mode')
+    if not include_builds:
+        cmd.append("--no-builds")
+    cp = subprocess.run(cmd, stdout=subprocess.PIPE)
+    output = cp.stdout.decode("utf-8")
+
+    # get header and conda dependencies from history-only mode, and pip dependencies from non history_only mode:
+    is_useful = True if history_only else False  # retain the header and conda part if history_only
+    result = []
+    for line in output.splitlines():
+        is_useful = set_usefulness(line, is_useful, history_only)  # remove none pip parts if in history only mode
+        result.append(line) if is_useful else None
+    return "\n".join(result)
+
+
+def set_usefulness(line, is_useful, history_only):
+    if "pip" in line and "pip=" not in line:
+        is_useful = False if history_only else True  # get pip if not history only
+    if "prefix" in line:
+        is_useful = False  # remove prefix what-so-ever
+    return is_useful
+
+
+def main():
+    env_data_pip = export_env(history_only=False)
+    env_data_conda = export_env(history_only=True)
+    env_data = env_data_conda + "\n" + env_data_pip
+    with open("conda_env.yml", "w") as f:
+        f.write(env_data)
+    logger.info(
+        f"Conda env export successfully done."
+        f"Please check file 'conda_env.yml' before push to pip, making sure no un-safe dependencies are accidentally "
+        f"listed in the dependency file."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/conda_env_export.py
+++ b/conda_env_export.py
@@ -2,7 +2,9 @@
 Export a Conda environment with --from-history, but also append
 Pip-installed dependencies
 
-For `conda_env.yml`, we dont use the following two commands, but this py file instead:
+For `conda env export`, we dont use the following two commands, but this py file instead.
+
+Reasons:
 - `Conda env export --from-history -f conda_env.yaml` does not contain pip installments
 - `Conda env export -f conda_env.yaml` pins dependencies too hard (add conda build number,
 which is os dependent, add os-denpendent libs as well).
@@ -12,7 +14,7 @@ This is adopted from https://gist.github.com/gwerbin/dab3cf5f8db07611c6e0aeec177
 Example:
     In root folder of this repo:
     >> which python # make sure you are in the right virtual env
-    >> python conda_env_export.py
+    >> python conda_env_export.py # a better alternative than `conda env export`
 """
 
 # TODO currently leave out python and pip, fix this.

--- a/root_logger.py
+++ b/root_logger.py
@@ -1,0 +1,15 @@
+import logging
+
+
+def logger():
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("[%(asctime)s]-[%(name)s]-[%(levelname)s] - %(message)s")
+    stream_handler.setFormatter(formatter)
+    root_logger.addHandler(stream_handler)
+
+    logging.basicConfig(filename="debug.log")
+    return root_logger

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,3 +1,11 @@
-from gresults_extract import get_results_count_pipeline
+from gtrends_extract import (create_pytrends_session, get_related_queries, process_related_query_response,
+    unpack_related_queries_response, create_related_queries_dataframe)
 
-__all__ = ["get_results_count_pipeline"]
+__all__ = [
+    "get_results_count_pipeline",
+    "assert_google_results",
+    "get_related_queries",
+    "process_related_query_response",
+    "unpack_related_queries_response",
+    "create_related_queries_dataframe"
+]

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,3 @@
+from gresults_extract import get_results_count_pipeline
+
+__all__ = ["get_results_count_pipeline"]

--- a/src/data/gresults_extract.py
+++ b/src/data/gresults_extract.py
@@ -1,7 +1,7 @@
 """
 Extract results count from Google with beautiful soup
 
-Methods take a list of keywords and return a dataframe. 
+Methods take a list of keywords and return a dataframe.
 
 """
 
@@ -11,9 +11,12 @@ from bs4 import BeautifulSoup
 from datetime import datetime
 import logging
 
+logger = logging.getLogger(__name__)
+
+
 def create_search_url(keyword_list, url="https://www.google.com/search?q="):
     """Create Google search URL for a keyword from keyword_list
-    
+
     Args:
         keyword_list (list): list of strings that contain the search keywords
         url (str): Google's base search url
@@ -22,46 +25,52 @@ def create_search_url(keyword_list, url="https://www.google.com/search?q="):
         list: Google search url like https://www.google.com/search?q=pizza
 
     """
-    search_query = [kw.replace(' ','+') for kw in keyword_list] # replace space with '+'
-    return [url+sq for sq in search_query]
+    search_query = [
+        kw.replace(" ", "+") for kw in keyword_list
+    ]  # replace space with '+'
+    return [url + sq for sq in search_query]
 
-    
+
 def get_results_count(keyword, user_agent):
     """Gets Google's result count for a keyword
 
     Args:
-        keyword (string): The keyword for which to get the results count 
+        keyword (string): The keyword for which to get the results count
         user_agent (string): For example {"User-Agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"}
 
     Returns:
         int: Results count
     """
-    result = requests.get(keyword, headers=user_agent)    
-    soup = BeautifulSoup(result.content, 'html.parser')
-    
+    result = requests.get(keyword, headers=user_agent)
+    soup = BeautifulSoup(result.content, "html.parser")
+
     #  string that contains results count 'About 1,410,000,000 results'
-    total_results_text = soup.find("div", {"id": "result-stats"}).find(text=True, recursive=False) 
-    
+    total_results_text = soup.find("div", {"id": "result-stats"}).find(
+        text=True, recursive=False
+    )
+
     # extract number
-    results_num = int(''.join([num for num in total_results_text if num.isdigit()]) )
-    
+    results_num = int("".join([num for num in total_results_text if num.isdigit()]))
+
     return results_num
 
 
-def get_results_count_pipeline(keyword_list, user_agent, url="https://www.google.com/search?q="):
+def get_results_count_pipeline(
+    keyword_list, user_agent, url="https://www.google.com/search?q="
+):
     """Google results count for each keyword of keyword_list in a dataframe
 
     Args:
-        keyword_list (list): The keywords for which to get the results count 
+        keyword_list (list): The keywords for which to get the results count
         user_agent (string): For example {"User-Agent": "Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36"}
         url (string): Google's base search URL like "https://www.google.com/search?q=" (default)
-    
+
     Returns:
         dataframe: Google results count and query metadata
 
-    Examples: 
+    Examples:
 
-        with open('../settings.yaml') as file: 
+        with open('../settings.yaml') as file:
            config = yaml.full_load(file)
         user_agent = config['query']['google_results']['user_agent']
         base_url = config['query']['google_results']['base_url']
@@ -69,33 +78,47 @@ def get_results_count_pipeline(keyword_list, user_agent, url="https://www.google
         result_counts = get_results_count_pipeline(keyword_list, user_agent, base_url)
     """
     search_urls = create_search_url(keyword_list)
-    result_count = [get_results_count(url, user_agent) for url in search_urls]  
-    
-    df = pd.DataFrame({'keyword': keyword_list, 
-                       'results_count': result_count, 
-                       'search_url': search_urls, 
-                       'query_timestamp': datetime.now()})
+    result_count = [get_results_count(url, user_agent) for url in search_urls]
+
+    df = pd.DataFrame(
+        {
+            "keyword": keyword_list,
+            "results_count": result_count,
+            "search_url": search_urls,
+            "query_timestamp": datetime.now(),
+        }
+    )
     # testing
     assert_google_results(df=df, keyword_list=keyword_list, url=url)
-    
+
     return df
 
 
 def assert_google_results(df, keyword_list, url="https://www.google.com/search?q="):
     """Ensures that dataframe meets expectations """
-    
+
     # expected dataframe for comparison
-    df_compare = pd.DataFrame({
-        'keyword': pd.Series([*keyword_list], dtype='object'),
-        'results_count': pd.Series([1 for i in keyword_list], dtype='int64'),
-        'search_url': pd.Series(create_search_url(keyword_list, url=url), dtype='object'),
-        'query_timestamp': pd.Series([datetime.now() for i in keyword_list], dtype='datetime64[ns]')
-    })
+    df_compare = pd.DataFrame(
+        {
+            "keyword": pd.Series([*keyword_list], dtype="object"),
+            "results_count": pd.Series([1 for i in keyword_list], dtype="int64"),
+            "search_url": pd.Series(
+                create_search_url(keyword_list, url=url), dtype="object"
+            ),
+            "query_timestamp": pd.Series(
+                [datetime.now() for i in keyword_list], dtype="datetime64[ns]"
+            ),
+        }
+    )
 
     # comparison to actual
     column_difference = set(df.columns).symmetric_difference(df_compare.columns)
-    assert len(column_difference) == 0, f"The following columns differ to reference dataframe: {column_difference}"
-    assert (df_compare.dtypes == df.dtypes).all(), f"Different dtypes for {df.dtypes}\n{df_compare.dtypes}"
+    assert (
+        len(column_difference) == 0
+    ), f"The following columns differ to reference dataframe: {column_difference}"
+    assert (
+        df_compare.dtypes == df.dtypes
+    ).all(), f"Different dtypes for {df.dtypes}\n{df_compare.dtypes}"
     assert len(df) == len(keyword_list), f"{len(df)} does not equal {len(keyword_list)}"
-    
+
     logging.info("Google results data meets expectations")

--- a/src/data/gresults_extract.py
+++ b/src/data/gresults_extract.py
@@ -64,6 +64,7 @@ def get_results_count_pipeline(keyword_list, user_agent, url="https://www.google
 
     Examples:
 
+        # TODO conform with doctest
         >> with open('../settings.yaml') as file:
            config = yaml.full_load(file)
         >> user_agent = config['query']['google_results']['user_agent']
@@ -108,3 +109,4 @@ def assert_google_results(df, keyword_list, url="https://www.google.com/search?q
     assert len(df) == len(keyword_list), f"{len(df)} does not equal {len(keyword_list)}"
 
     logging.info("Google results data meets expectations")
+    # TODO how about using df.equal(), less verbose

--- a/src/data/gresults_extract.py
+++ b/src/data/gresults_extract.py
@@ -25,9 +25,7 @@ def create_search_url(keyword_list, url="https://www.google.com/search?q="):
         list: Google search url like https://www.google.com/search?q=pizza
 
     """
-    search_query = [
-        kw.replace(" ", "+") for kw in keyword_list
-    ]  # replace space with '+'
+    search_query = [kw.replace(" ", "+") for kw in keyword_list]  # replace space with '+'
     return [url + sq for sq in search_query]
 
 
@@ -45,9 +43,7 @@ def get_results_count(keyword, user_agent):
     soup = BeautifulSoup(result.content, "html.parser")
 
     #  string that contains results count 'About 1,410,000,000 results'
-    total_results_text = soup.find("div", {"id": "result-stats"}).find(
-        text=True, recursive=False
-    )
+    total_results_text = soup.find("div", {"id": "result-stats"}).find(text=True, recursive=False)
 
     # extract number
     results_num = int("".join([num for num in total_results_text if num.isdigit()]))
@@ -55,9 +51,7 @@ def get_results_count(keyword, user_agent):
     return results_num
 
 
-def get_results_count_pipeline(
-    keyword_list, user_agent, url="https://www.google.com/search?q="
-):
+def get_results_count_pipeline(keyword_list, user_agent, url="https://www.google.com/search?q="):
     """Google results count for each keyword of keyword_list in a dataframe
 
     Args:
@@ -70,12 +64,12 @@ def get_results_count_pipeline(
 
     Examples:
 
-        with open('../settings.yaml') as file:
+        >> with open('../settings.yaml') as file:
            config = yaml.full_load(file)
-        user_agent = config['query']['google_results']['user_agent']
-        base_url = config['query']['google_results']['base_url']
-        keyword_list = ['pizza', 'lufthansa']
-        result_counts = get_results_count_pipeline(keyword_list, user_agent, base_url)
+        >> user_agent = config['query']['google_results']['user_agent']
+        >> base_url = config['query']['google_results']['base_url']
+        >> keyword_list = ['pizza', 'lufthansa']
+        >> result_counts = get_results_count_pipeline(keyword_list, user_agent, base_url)
     """
     search_urls = create_search_url(keyword_list)
     result_count = [get_results_count(url, user_agent) for url in search_urls]
@@ -102,23 +96,15 @@ def assert_google_results(df, keyword_list, url="https://www.google.com/search?q
         {
             "keyword": pd.Series([*keyword_list], dtype="object"),
             "results_count": pd.Series([1 for i in keyword_list], dtype="int64"),
-            "search_url": pd.Series(
-                create_search_url(keyword_list, url=url), dtype="object"
-            ),
-            "query_timestamp": pd.Series(
-                [datetime.now() for i in keyword_list], dtype="datetime64[ns]"
-            ),
+            "search_url": pd.Series(create_search_url(keyword_list, url=url), dtype="object"),
+            "query_timestamp": pd.Series([datetime.now() for i in keyword_list], dtype="datetime64[ns]"),
         }
     )
 
     # comparison to actual
     column_difference = set(df.columns).symmetric_difference(df_compare.columns)
-    assert (
-        len(column_difference) == 0
-    ), f"The following columns differ to reference dataframe: {column_difference}"
-    assert (
-        df_compare.dtypes == df.dtypes
-    ).all(), f"Different dtypes for {df.dtypes}\n{df_compare.dtypes}"
+    assert len(column_difference) == 0, f"The following columns differ to reference dataframe: {column_difference}"
+    assert (df_compare.dtypes == df.dtypes).all(), f"Different dtypes for {df.dtypes}\n{df_compare.dtypes}"
     assert len(df) == len(keyword_list), f"{len(df)} does not equal {len(keyword_list)}"
 
     logging.info("Google results data meets expectations")

--- a/src/data/gtrends_extract.py
+++ b/src/data/gtrends_extract.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_pytrends_session():
-    """Create pytrends TrendReq() session on which .build_payload() can be called """
+    """Create pytrends TrendReq() session on which .build_payload() can be called."""
     pytrends_session = TrendReq()
 
     return pytrends_session

--- a/src/data/gtrends_extract.py
+++ b/src/data/gtrends_extract.py
@@ -2,7 +2,7 @@
 Extract data from Google trends with the pytrends package
 Methods take one keyword, call pytrends and return processed data as CSV or dataframe
 
-There are two main functions: 
+There are two main functions:
     * get_related_queries_pipeline: Returns dataframe of trending searches for a given topic
     * get_interest_over_time: Returns CSV with interest over time for specified keywords
 
@@ -12,35 +12,42 @@ import pandas as pd
 import numpy as np
 import logging
 from datetime import datetime
-from random import randint 
+from random import randint
 from pytrends.request import TrendReq
-import streamlit as st
-from utilities import (n_batch, list_batch, df_to_csv, timestamp_now, sleep_countdown)
+
+from utilities import list_batch, df_to_csv, sleep_countdown
+
+logger = logging.getLogger(__name__)
+
 
 def create_pytrends_session():
     """Create pytrends TrendReq() session on which .build_payload() can be called """
-    pytrends_session = TrendReq() 
+    pytrends_session = TrendReq()
 
     return pytrends_session
+
 
 # ----------------------------------------------------------
 # Google trends: related queries
 # ----------------------------------------------------------
 
-def get_related_queries(pytrends_session, keyword_list, cat=0, geo=''):
-    """Returns a dictionary with a dataframe for each keyword 
+
+def get_related_queries(pytrends_session, keyword_list, cat=0, geo=""):
+    """Returns a dictionary with a dataframe for each keyword
     Calls pytrend's related_queries()
-    
+
     Args:
         pytrends_session (object): TrendReq() session of pytrend
-        keyword_list (list): Used as input for query and passed to TrendReq().build_payload() 
+        keyword_list (list): Used as input for query and passed to TrendReq().build_payload()
         cat (int): see https://github.com/pat310/google-trends-api/wiki/Google-Trends-Categories
         geo (str): Geolocation like US, UK
 
     Returns:
-        Dictionary: Dict with dataframes with related query results 
-    """    
-    assert isinstance(keyword_list, list), f"keyword_list should be string. Instead of type {type(keyword_list)}"
+        Dictionary: Dict with dataframes with related query results
+    """
+    assert isinstance(
+        keyword_list, list
+    ), f"keyword_list should be string. Instead of type {type(keyword_list)}"
 
     df_related_queries = pd.DataFrame()
 
@@ -54,17 +61,25 @@ def get_related_queries(pytrends_session, keyword_list, cat=0, geo=''):
 
     return df_related_queries
 
+
 def process_related_query_response(response, kw, geo, ranking):
     """ Helper function for unpack_related_queries_response() """
     try:
         df = response[kw][ranking]
-        df[['keyword', 'ranking', 'geo', 'query_timestamp']] = [
-            kw, ranking, geo, datetime.now()]
+        df[["keyword", "ranking", "geo", "query_timestamp"]] = [
+            kw,
+            ranking,
+            geo,
+            datetime.now(),
+        ]
     except:
         logging.info(f"Append empty dataframe for {ranking}: {kw}")
-        return pd.DataFrame(columns=['query', 'value', 'keyword', 'ranking', 'geo', 'query_timestamp'])
+        return pd.DataFrame(
+            columns=["query", "value", "keyword", "ranking", "geo", "query_timestamp"]
+        )
 
     return df
+
 
 def unpack_related_queries_response(response):
     """Unpack response from dictionary and create one dataframe for each ranking and each keyword """
@@ -75,44 +90,57 @@ def unpack_related_queries_response(response):
 
     return response, ranking, keywords
 
-def create_related_queries_dataframe(response, rankings, keywords, geo_description='global'):
+
+def create_related_queries_dataframe(
+    response, rankings, keywords, geo_description="global"
+):
     """Returns a single dataframe of related queries for a list of keywords
     and each ranking (either 'top' or 'rising')
     """
     df_list = []
     for r in rankings:
         for kw in keywords:
-            df_list.append(process_related_query_response(
-                response, kw=kw, ranking=r, geo=geo_description))
+            df_list.append(
+                process_related_query_response(
+                    response, kw=kw, ranking=r, geo=geo_description
+                )
+            )
 
     return pd.concat(df_list)
 
-def get_related_queries_pipeline(pytrends_session, keyword_list, cat=0, geo='', geo_description='global'): 
+
+def get_related_queries_pipeline(
+    pytrends_session, keyword_list, cat=0, geo="", geo_description="global"
+):
     """Returns all response data for pytrend's .related_queries() in a single dataframe
-    
+
     Example usage:
 
         pytrends_session = create_pytrends_session()
         df = get_related_queries_pipeline(pytrends_session, keyword_list=['pizza', 'lufthansa'])
     """
-    response = get_related_queries(pytrends_session=pytrends_session, keyword_list=keyword_list, cat=cat, geo=geo) # 
-    response, rankings, keywords  = unpack_related_queries_response(response=response)
+    response = get_related_queries(
+        pytrends_session=pytrends_session, keyword_list=keyword_list, cat=cat, geo=geo
+    )  #
+    response, rankings, keywords = unpack_related_queries_response(response=response)
     df_trends = create_related_queries_dataframe(
-        response=response, 
-        rankings=rankings, 
-        keywords=keywords, 
-        geo_description=geo_description)
-    
+        response=response,
+        rankings=rankings,
+        keywords=keywords,
+        geo_description=geo_description,
+    )
+
     return df_trends
-
-
 
 
 # ----------------------------------------------------------
 # Google trends: Interest over time
 # ----------------------------------------------------------
 
-def process_interest_over_time(df_query_result, keywords, date_index=None, query_length=261):
+
+def process_interest_over_time(
+    df_query_result, keywords, date_index=None, query_length=261
+):
     """Process query results
             * check for empty response --> create df with 0s if empty
             * drop isPartial rows and column
@@ -120,40 +148,53 @@ def process_interest_over_time(df_query_result, keywords, date_index=None, query
 
     Args:
         df_query_result (pd.DataFrame): dataframe containing query result (could be empty)
-        date_index (pd.Series): series with date form a basic query to construct df for empty reponses 
-        
+        date_index (pd.Series): series with date form a basic query to construct df for empty reponses
+
     Returns:
-        Dataframe: contains query results in long format 
+        Dataframe: contains query results in long format
         (rows: keywords, columns: search interest over time)
     """
     # non-empty df
     if df_query_result.shape[0] != 0:
         # reset_index to preserve date information, drop isPartial column
-        df_query_result_processed = df_query_result.reset_index()\
-            .drop(['isPartial'], axis=1)
+        df_query_result_processed = df_query_result.reset_index().drop(
+            ["isPartial"], axis=1
+        )
 
-        df_query_result_long = pd.melt(df_query_result_processed, id_vars=['date'], var_name='keyword', value_name='search_interest')
+        df_query_result_long = pd.melt(
+            df_query_result_processed,
+            id_vars=["date"],
+            var_name="keyword",
+            value_name="search_interest",
+        )
 
         # long format (date, keyword, search interest)
         return df_query_result_long
 
     # empty df: no search result for any keyword
-    else:        
+    else:
         # create empty df with 0s
         query_length = len(date_index) if date_index is not None else query_length
 
-        df_zeros = pd.DataFrame(np.zeros((query_length*len(keywords), 3)), columns=['date','keyword', 'search_interest'])
+        df_zeros = pd.DataFrame(
+            np.zeros((query_length * len(keywords), 3)),
+            columns=["date", "keyword", "search_interest"],
+        )
         # replace 0s with dates
-        df_zeros['date'] = pd.concat([date_index for i in range(len(keywords))], axis=0).reset_index(drop=True) if date_index is not None else 0
-        # replace 0s with keywords 
-        df_zeros['keyword'] = np.repeat(keywords, query_length)
-
+        df_zeros["date"] = (
+            pd.concat([date_index for i in range(len(keywords))], axis=0).reset_index(
+                drop=True
+            )
+            if date_index is not None
+            else 0
+        )
+        # replace 0s with keywords
+        df_zeros["keyword"] = np.repeat(keywords, query_length)
 
         return df_zeros
 
 
-
-def query_interest_over_time(keywords, date_index=None, timeframe='today 5-y'):
+def query_interest_over_time(keywords, date_index=None, timeframe="today 5-y"):
     """Forward keywords to Google Trends API and process results into long format
 
     Args:
@@ -165,51 +206,61 @@ def query_interest_over_time(keywords, date_index=None, timeframe='today 5-y'):
     """
     # init pytrends
     pt = create_pytrends_session()
-    pt.build_payload(kw_list=keywords, timeframe=timeframe) 
+    pt.build_payload(kw_list=keywords, timeframe=timeframe)
 
     # load search interest over time
     df_query_result_raw = pt.interest_over_time()
 
     # preprocess query results
-    df_query_result_processed = process_interest_over_time(df_query_result_raw, keywords, date_index)
+    df_query_result_processed = process_interest_over_time(
+        df_query_result_raw, keywords, date_index
+    )
 
     return df_query_result_processed
 
 
-def get_query_date_index(timeframe='today 5-y'):
+def get_query_date_index(timeframe="today 5-y"):
     """Queries Google trends to have a valid index for query results that returned an empty dataframe
     Args:
-        timeframe (string): 
+        timeframe (string):
 
     Returns:
         pd.Series: date index of Google trend's interest_over_time()
     """
-    
+
     # init pytrends with query that ALWAYS works
     pt = create_pytrends_session()
-    pt.build_payload(kw_list=['pizza', 'lufthansa'], timeframe=timeframe)
+    pt.build_payload(kw_list=["pizza", "lufthansa"], timeframe=timeframe)
     df = pt.interest_over_time()
 
     # set date as column
-    df = df.rename_axis('date').reset_index()
-
+    df = df.rename_axis("date").reset_index()
 
     return df.date
 
-#--------------------------------------------------- 
-# MAIN QUERY FUNCTION
-#---------------------------------------------------
 
-def get_interest_over_time(keyword_list, filepath, filepath_failed, timeframe='today 5-y', max_retries=3, timeout=10):
-    """Workhorse function to query Google Trend's interest_over_time() function. 
-    It respects the query's requirements like 
+# ---------------------------------------------------
+# MAIN QUERY FUNCTION
+# ---------------------------------------------------
+
+
+def get_interest_over_time(
+    keyword_list,
+    filepath,
+    filepath_failed,
+    timeframe="today 5-y",
+    max_retries=3,
+    timeout=10,
+):
+    """Workhorse function to query Google Trend's interest_over_time() function.
+    It respects the query's requirements like
         * max. 5 keywords per query, handled by list_batch()
         * a basic date index for queries returning empty dataframe
         * randomized timeout to not bust rate limits
-    
+
     Error handling:
         * retry after query error with increased timeout
-        * when a query fails after retries, related keywords are stored in csv in filepath_failed. 
+        * when a query fails after retries, related keywords are stored in csv in filepath_failed.
 
 
 
@@ -217,7 +268,7 @@ def get_interest_over_time(keyword_list, filepath, filepath_failed, timeframe='t
         keyword_list (list): strings used for the google trends query
         filepath (string): csv to store successful query results
         filepath_failed (string): csv to store unsuccessful keywords
-        max_retries (int): how often retry 
+        max_retries (int): how often retry
         timeout (int): time to wait in seconds btw. queries
 
     Returns:
@@ -229,26 +280,28 @@ def get_interest_over_time(keyword_list, filepath, filepath_failed, timeframe='t
     # divide list into batches of max 5 elements (requirement from Gtrends)
     kw_batches = list_batch(lst=keyword_list, n=5)
 
-
-    for i, kw_batch in enumerate(kw_batches): 
+    for i, kw_batch in enumerate(kw_batches):
         # retry until max_retries reached
-        for attempt in range(max_retries): 
+        for attempt in range(max_retries):
 
-            # random int from range around timeout 
-            timeout_randomized = randint(timeout-3,timeout+3)
+            # random int from range around timeout
+            timeout_randomized = randint(timeout - 3, timeout + 3)
             try:
                 df = query_interest_over_time(kw_batch, date_index=date_index)
-            
+
             # query unsuccessful
             except Exception as e:
-                logging.error(f"query_interest_over_time() failed in get_interest_over_time with: {e}")
-                timeout += 3 # increase timetout to be safe
+                logging.error(
+                    f"query_interest_over_time() failed in get_interest_over_time with: {e}"
+                )
+                timeout += 3  # increase timetout to be safe
                 sleep_countdown(timeout_randomized, print_step=2)
-            
 
-            # query was successful: store results, sleep 
+            # query was successful: store results, sleep
             else:
-                logging.info(f"{i+1}/{len(list(kw_batches))} get_interest_over_time() query successful")
+                logging.info(
+                    f"{i+1}/{len(list(kw_batches))} get_interest_over_time() query successful"
+                )
                 df_to_csv(df, filepath=filepath)
                 sleep_countdown(timeout_randomized)
                 break

--- a/src/data/utilities.py
+++ b/src/data/utilities.py
@@ -6,15 +6,14 @@ list_flatten: flatten nested list
 n_batch: generator for n-sized list batches
 list_batch: get n-sized chunks from n_batch generator
 df_to_csv: write csv either create new or append to existing
-timestamp_now: get string  
+timestamp_now: get string
 sleep_countdown(): countdown in console
 
 """
 
 import os
 import sys
-import time 
-import pandas as pd
+import time
 
 
 def list_remove_duplicates(l):
@@ -22,53 +21,59 @@ def list_remove_duplicates(l):
 
     Args:
         list with string elements
-    
+
     Returns:
         Sorted list without duplicates
-    
+
     """
     seen = set()
     seen_add = seen.add
     return [x for x in l if not (x in seen or seen_add(x))]
 
+
 def list_flatten(nested_list):
     """Flattens nested list"""
     return [element for sublist in nested_list for element in sublist]
 
+
 def n_batch(lst, n=5):
     """Yield successive n-sized chunks from list lst
-    
+
     Args:
-        lst (list): list object 
+        lst (list): list object
         n (int): batch size to divide list
-        
-    Returns: 
+
+    Returns:
         List: nested list, divided lst into batches of len(lst)/n lists
     """
-    
+
     for i in range(0, len(lst), n):
-        yield lst[i:i + n]
+        yield lst[i : i + n]
+
 
 def list_batch(lst, n=5):
     """"Divides a list into a list of lists with n-sized length"""
     return list(n_batch(lst=lst, n=n))
 
+
 def df_to_csv(df, filepath):
     """Export df to CSV. If it exists already, append data."""
     # file does not exist --> write header
-    if not os.path.isfile(f'{filepath}'):
-        df.to_csv(f'{filepath}', index=False)
+    if not os.path.isfile(f"{filepath}"):
+        df.to_csv(f"{filepath}", index=False)
     # file exists --> append data without header
     else:
-        df.to_csv(f'{filepath}', index=False, header=False, mode='a')
+        df.to_csv(f"{filepath}", index=False, header=False, mode="a")
+
 
 def timestamp_now():
     """Create timestamp string in format: yyyy/mm/dd-hh/mm/ss"""
     return f'{strftime("%Y%m%d-%H%M%S")}'
 
+
 def sleep_countdown(duration, print_step=2):
     """Sleep for certain duration and print remaining time in steps of print_step
-    
+
     Args:
         duration (int): duration of timeout
         print_step (int): steps to print countdown
@@ -76,7 +81,7 @@ def sleep_countdown(duration, print_step=2):
     Returns
         None: Countdown in console
     """
-    for i in range(duration,0,-print_step):
+    for i in range(duration, 0, -print_step):
         time.sleep(print_step)
-        sys.stdout.write(str(i-print_step)+' ')
+        sys.stdout.write(str(i - print_step) + " ")
         sys.stdout.flush()

--- a/src/data/utilities.py
+++ b/src/data/utilities.py
@@ -68,7 +68,7 @@ def df_to_csv(df, filepath):
 
 def timestamp_now():
     """Create timestamp string in format: yyyy/mm/dd-hh/mm/ss"""
-    return f'{strftime("%Y%m%d-%H%M%S")}'
+    return f'{time.strftime("%Y%m%d-%H%M%S")}'
 
 
 def sleep_countdown(duration, print_step=2):

--- a/src/data/yahoofinance_extract.py
+++ b/src/data/yahoofinance_extract.py
@@ -8,104 +8,123 @@ from pytickersymbols import PyTickerSymbols
 import logging
 import numpy as np
 import pandas as pd
-import re 
 import yaml
 
 
-#---------------------------------------------------
+# ---------------------------------------------------
 # INDEX DETAILS
-#---------------------------------------------------
+# ---------------------------------------------------
+
 
 def get_index_stock_details(pytickersymbols, index_name):
-    """Get firm name, stock ticker for a specified stock index. 
-    Available indices from pytickersymbols: PyTickerSymbols().get_all_indices() 
+    """Get firm name, stock ticker for a specified stock index.
+    Available indices from pytickersymbols: PyTickerSymbols().get_all_indices()
     See https://github.com/portfolioplus/pytickersymbols for package details
 
     Args:
         pytickersymbols (object): Init object from PyTickerSymbols()
-        index_name (str): Index name from PyTickerSymbols().get_all_indices() 
-    
+        index_name (str): Index name from PyTickerSymbols().get_all_indices()
+
     Returns:
-        Dataframe: 
+        Dataframe:
     """
     index_details = pd.DataFrame(pytickersymbols.get_stocks_by_index(index_name))
-    
+
     # string encoding
-    try: 
-        index_details.name = index_details.name.str.encode('latin-1').str.decode('utf-8')
-    except Exception as e: 
+    try:
+        index_details.name = index_details.name.str.encode("latin-1").str.decode(
+            "utf-8"
+        )
+    except Exception as e:
         logging.warning(f"Encoding error for {index_name}")
-        index_details.name = index_details.name.str.encode('utf-8').str.decode('utf-8')
+        index_details.name = index_details.name.str.encode("utf-8").str.decode("utf-8")
 
     # retrieve yahoo ticker symbol
-    index_details['yahoo_ticker'] = index_details.symbols.apply(lambda x: x[0]['yahoo'] if len(x) > 1 else np.nan)
+    index_details["yahoo_ticker"] = index_details.symbols.apply(
+        lambda x: x[0]["yahoo"] if len(x) > 1 else np.nan
+    )
     index_details.yahoo_ticker.fillna(index_details.symbol, inplace=True)
 
     # set ticker as index
-    index_details.set_index('yahoo_ticker', inplace=True, drop=False)
-    index_details.drop(columns=['id'], inplace=True)
+    index_details.set_index("yahoo_ticker", inplace=True, drop=False)
+    index_details.drop(columns=["id"], inplace=True)
 
     return index_details
 
-#---------------------------------------------------
+
+# ---------------------------------------------------
 # FIRM-LEVEL ESG DATA
-#---------------------------------------------------
+# ---------------------------------------------------
+
 
 def get_esg_details(yahoo_ticker):
     """Returns esg information for suitable yahoo ticker which can be string, pd.Series or list"""
-    
+
     # convert series to list
-    if isinstance(yahoo_ticker, pd.Series): 
+    if isinstance(yahoo_ticker, pd.Series):
         yahoo_ticker = yahoo_ticker.to_list()
-    
+
     ticker_details = Ticker(yahoo_ticker)
     esg_df = pd.DataFrame(ticker_details.esg_scores).T
 
     return esg_df
 
+
 @st.cache(allow_output_mutation=True)
 def get_index_firm_esg(pytickersymbols, index_name):
     """Merge index, firm name and esg data"""
-    index_stocks = get_index_stock_details(pytickersymbols=pytickersymbols, index_name=index_name)
+    index_stocks = get_index_stock_details(
+        pytickersymbols=pytickersymbols, index_name=index_name
+    )
     esg_details = get_esg_details(yahoo_ticker=index_stocks.yahoo_ticker)
-    
+
     stocks_esg = pd.concat([index_stocks, esg_details], axis=1)
 
     return stocks_esg
 
+
 def replace_firm_names(df, settings_path):
     """Replace firm names as specified in settings.yaml"""
 
-    with open(settings_path, encoding='utf8') as file:
+    with open(settings_path, encoding="utf8") as file:
         settings = yaml.full_load(file)
 
-    try: settings['query']['firm_name']
-    except: logging.warning("No firm names specified in settings['query']['firm_name']. \
-        Firm names still contain legal suffix which compromises search results.")
-    assert "name" in df.columns , "Dataframe has no name column. Firm names cannot be replaced."
+    try:
+        settings["query"]["firm_name"]
+    except:
+        logging.warning(
+            "No firm names specified in settings['query']['firm_name']. \
+        Firm names still contain legal suffix which compromises search results."
+        )
+    assert (
+        "name" in df.columns
+    ), "Dataframe has no name column. Firm names cannot be replaced."
 
-    replace_firm_names = settings['query']['firm_names']
-    df['firm_name'] = df.name.replace(replace_firm_names, regex=True)
+    replace_firm_names = settings["query"]["firm_names"]
+    df["firm_name"] = df.name.replace(replace_firm_names, regex=True)
 
     return df
+
 
 def remove_missing_esg_firms(esg_df, missing_placeholder="No fundamentals data"):
     """Drops firms that have no ESG scores. Placeholder from Yahoo"""
     return esg_df.loc[~esg_df.peerGroup.str.contains(missing_placeholder)]
 
+
 def get_esg_controversy_keywords(settings_path):
     """Load controversy keywords from settings.yaml"""
 
-    with open(settings_path, encoding='utf8') as file:
+    with open(settings_path, encoding="utf8") as file:
         settings = yaml.full_load(file)
 
-    controversies = settings['esg']['negative']
+    controversies = settings["esg"]["negative"]
 
     return controversies
-    
+
+
 def create_query_keywords(esg_df, keyword_list, explode=True):
     """Construct query keywords from firm_name and a list of keywords
-    
+
     Args:
         esg_df (Dataframe): Data from yahooquery Ticker(yahoo_ticker).esg_scores, processed firm names
         keyword_list (list): list of strings that are attached to each firm name
@@ -115,10 +134,15 @@ def create_query_keywords(esg_df, keyword_list, explode=True):
         Dataframe: added query_keyword column (firm_name + keyword)
 
     """
-    esg_df['query_keyword'] = esg_df.firm_name.apply(lambda x: [x+kw for kw in keyword_list])
+    esg_df["query_keyword"] = esg_df.firm_name.apply(
+        lambda x: [x + kw for kw in keyword_list]
+    )
 
-    if explode: return esg_df.explode(column='query_keyword')
-    else: return esg_df
+    if explode:
+        return esg_df.explode(column="query_keyword")
+    else:
+        return esg_df
+
 
 def esg_firm_query_keywords_pipeline(index_name, path_to_settings):
     """ESG scores, processed firm names and firm name query strings in a dataframe.
@@ -126,16 +150,18 @@ def esg_firm_query_keywords_pipeline(index_name, path_to_settings):
     Args:
         index_name (string): Index name, one of PyTickerSymbols().get_all_indices()
         path_to_settings (string): path to settings.yaml, where all esg keywords are specified
-    
+
     Returns:
         Dataframe: esg scores and related data from Yahoo!Finance incl. processed firm names and query keywords
 
     """
     pytickersymbols = PyTickerSymbols()
     controversy_keywords = get_esg_controversy_keywords(path_to_settings)
-    esg_df = (get_index_firm_esg(pytickersymbols=pytickersymbols, index_name=index_name)
-                        .pipe(replace_firm_names, settings_path=path_to_settings)
-                        .pipe(remove_missing_esg_firms)
-                        .pipe(create_query_keywords, keyword_list=controversy_keywords))
+    esg_df = (
+        get_index_firm_esg(pytickersymbols=pytickersymbols, index_name=index_name)
+        .pipe(replace_firm_names, settings_path=path_to_settings)
+        .pipe(remove_missing_esg_firms)
+        .pipe(create_query_keywords, keyword_list=controversy_keywords)
+    )
 
     return esg_df

--- a/src/data/yahoofinance_extract.py
+++ b/src/data/yahoofinance_extract.py
@@ -32,17 +32,13 @@ def get_index_stock_details(pytickersymbols, index_name):
 
     # string encoding
     try:
-        index_details.name = index_details.name.str.encode("latin-1").str.decode(
-            "utf-8"
-        )
+        index_details.name = index_details.name.str.encode("latin-1").str.decode("utf-8")
     except Exception as e:
         logging.warning(f"Encoding error for {index_name}")
         index_details.name = index_details.name.str.encode("utf-8").str.decode("utf-8")
 
     # retrieve yahoo ticker symbol
-    index_details["yahoo_ticker"] = index_details.symbols.apply(
-        lambda x: x[0]["yahoo"] if len(x) > 1 else np.nan
-    )
+    index_details["yahoo_ticker"] = index_details.symbols.apply(lambda x: x[0]["yahoo"] if len(x) > 1 else np.nan)
     index_details.yahoo_ticker.fillna(index_details.symbol, inplace=True)
 
     # set ticker as index
@@ -73,9 +69,7 @@ def get_esg_details(yahoo_ticker):
 @st.cache(allow_output_mutation=True)
 def get_index_firm_esg(pytickersymbols, index_name):
     """Merge index, firm name and esg data"""
-    index_stocks = get_index_stock_details(
-        pytickersymbols=pytickersymbols, index_name=index_name
-    )
+    index_stocks = get_index_stock_details(pytickersymbols=pytickersymbols, index_name=index_name)
     esg_details = get_esg_details(yahoo_ticker=index_stocks.yahoo_ticker)
 
     stocks_esg = pd.concat([index_stocks, esg_details], axis=1)
@@ -96,9 +90,7 @@ def replace_firm_names(df, settings_path):
             "No firm names specified in settings['query']['firm_name']. \
         Firm names still contain legal suffix which compromises search results."
         )
-    assert (
-        "name" in df.columns
-    ), "Dataframe has no name column. Firm names cannot be replaced."
+    assert "name" in df.columns, "Dataframe has no name column. Firm names cannot be replaced."
 
     replace_firm_names = settings["query"]["firm_names"]
     df["firm_name"] = df.name.replace(replace_firm_names, regex=True)
@@ -134,9 +126,7 @@ def create_query_keywords(esg_df, keyword_list, explode=True):
         Dataframe: added query_keyword column (firm_name + keyword)
 
     """
-    esg_df["query_keyword"] = esg_df.firm_name.apply(
-        lambda x: [x + kw for kw in keyword_list]
-    )
+    esg_df["query_keyword"] = esg_df.firm_name.apply(lambda x: [x + kw for kw in keyword_list])
 
     if explode:
         return esg_df.explode(column="query_keyword")

--- a/src/pipeline/demo.py
+++ b/src/pipeline/demo.py
@@ -1,0 +1,105 @@
+import datetime
+from pathlib import Path
+from typing import Optional, Union, List
+import logging
+
+import imageio
+from io import BytesIO
+
+import prefect
+from prefect import task, Parameter, Flow
+from prefect.engine.signals import SKIP
+from prefect.tasks.shell import ShellTask
+from prefect.executors import LocalDaskExecutor
+
+Runable = Optional[Union[str, List[str]]]
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(
+    filename="debug.log",
+    format="[%(asctime)s][%(levelname)-4s]: %(message)s",
+    level=logging.DEBUG,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+@task
+def curl_cmd(url: str, file: str) -> str:
+    """
+    The curl command we wish to execute.
+    """
+    prefect.context.get("logger")
+    if Path(file).exists():
+        raise SKIP("Image data file already exists.")
+    return f"curl -fL -o {file} {url}"
+
+
+download: Runable = ShellTask(name="curl_task", max_retries=2, retry_delay=datetime.timedelta(seconds=10))
+
+
+@task(skip_on_upstream_skip=False)
+def load_and_split(fname: str) -> list:
+    """
+    Loads image data file at `fname` and splits it into
+    multiple frames.  Returns a list of bytes, one element
+    for each frame.
+    """
+    prefect.context.get("logger")
+    with open(fname, "rb") as f:
+        imgs = f.read()
+
+    return [img for img in imgs.split(b"\n" * 4) if img]
+
+
+@task
+def write_to_disk(image: bytes) -> bytes:
+    """
+    Given a single image represented as bytes, writes the image
+    to the present working directory with a filename determined
+    by `map_index`.  Returns the image bytes.
+    """
+    prefect.context.get("logger")
+    frame_no = prefect.context.get("map_index")
+    Path("src/pipeline/temp/frames").touch()
+    # make sure the path exists, as prefect does not populate path for you
+    frame_path = Path("src/pipeline/temp/frames/frame_{0:0=2d}.gif".format(frame_no))
+    with open(frame_path, "wb") as f:
+        f.write(image)
+    return image
+
+
+@task
+def combine_to_gif(image_bytes: list, gif_file: Path) -> None:
+    """
+    Given a list of ordered images represented as bytes,
+    combines them into a single GIF stored in the present working directory.
+    """
+    prefect.context.get("logger")
+    images = [imageio.imread(BytesIO(image)) for image in image_bytes]
+    imageio.mimsave(gif_file, images)
+
+
+with Flow("Image ETL") as flow:
+    Path("src/pipeline/temp").touch()
+    image_path = Path("src/pipeline/temp/image-data.img")
+    gif_path = Path("src/pipeline/temp/comb.gif")
+
+    DATA_URL = Parameter("DATA_URL", default="https://github.com/cicdw/image-data/blob/master/all-images.img?raw=true")
+    DATA_FILE = Parameter("DATA_FILE", default=image_path)
+
+    # Extract
+    command = curl_cmd(DATA_URL, DATA_FILE)
+    curl = download(command=command)
+
+    # Transform
+    # we use the `upstream_tasks` keyword to specify non-data dependencies
+    images = load_and_split(fname=DATA_FILE, upstream_tasks=[curl])
+
+    # Load
+    frames = write_to_disk.map(images)
+    combine_to_gif(frames, gif_path)
+
+if __name__ == "__main__":
+    flow.visualize()
+    flow.executor = LocalDaskExecutor(scheduler="threads", num_workers=4)
+    flow.run()

--- a/src/pipeline/main.py
+++ b/src/pipeline/main.py
@@ -1,0 +1,10 @@
+import prefect
+from prefect import task, Parameter, Flow
+
+from src.data.gtrends_extract import (
+    create_pytrends_session,
+    get_related_queries,
+    process_related_query_response,
+    unpack_related_queries_response,
+    create_related_queries_dataframe,
+)

--- a/src/visualization/tsf_plots.py
+++ b/src/visualization/tsf_plots.py
@@ -4,28 +4,37 @@ Make visualizations with plotly
 
 import plotly.io as pio
 import plotly.graph_objects as go
-from plotly.subplots import make_subplots
-import plotly.express as px
-import chart_studio.plotly as cs
 
 from datetime import datetime
 import logging
+
+logger = logging.getLogger(__name__)
 
 
 def set_layout_template():
     """ Creates watermarks and applies colors"""
     # watermarks
-    watermark_date = "Updated {}".format(datetime.now().strftime("%d.%B%Y") )# date watermark
+    watermark_date = "Updated {}".format(
+        datetime.now().strftime("%d.%B%Y")
+    )  # date watermark
     watermark_url = "towardssustainablefinance.com"
-    
+
     # colorscale
-    tsf_colorscale = ["#4d886d", "#f3dab9", "#9bcab8", "#829fa5", "#dc9b4d", "#4a82a1", "#cfaea5", '#D5E6E0']
-    
+    tsf_colorscale = [
+        "#4d886d",
+        "#f3dab9",
+        "#9bcab8",
+        "#829fa5",
+        "#dc9b4d",
+        "#4a82a1",
+        "#cfaea5",
+        "#D5E6E0",
+    ]
 
     pio.templates["tsf"] = go.layout.Template(
-        layout_colorway=tsf_colorscale, 
-        layout_hovermode= 'closest', 
-        layout_font_family='Verdana',
+        layout_colorway=tsf_colorscale,
+        layout_hovermode="closest",
+        layout_font_family="Verdana",
         layout_annotations=[
             dict(
                 name="watermark",
@@ -38,7 +47,7 @@ def set_layout_template():
                 x=1,
                 y=-0.15,
                 showarrow=False,
-            ), 
+            ),
             dict(
                 name="watermark2",
                 text=watermark_date,
@@ -50,7 +59,7 @@ def set_layout_template():
                 x=0,
                 y=0.1,
                 showarrow=False,
-            )
-        ]
+            ),
+        ],
     )
-    pio.templates.default = 'tsf'
+    pio.templates.default = "tsf"

--- a/src/visualization/tsf_plots.py
+++ b/src/visualization/tsf_plots.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 def set_layout_template():
     """ Creates watermarks and applies colors"""
     # watermarks
-    watermark_date = "Updated {}".format(
-        datetime.now().strftime("%d.%B%Y")
-    )  # date watermark
+    watermark_date = "Updated {}".format(datetime.now().strftime("%d.%B%Y"))  # date watermark
     watermark_url = "towardssustainablefinance.com"
 
     # colorscale

--- a/streamlit/0_ps_exploration.py
+++ b/streamlit/0_ps_exploration.py
@@ -19,9 +19,7 @@ from src.data.gtrends_extract import get_interest_over_time
 from tsf_plots import set_layout_template
 
 
-esg_df = yq.esg_firm_query_keywords_pipeline(
-    index_name="DAX", path_to_settings="../settings.yaml"
-)
+esg_df = yq.esg_firm_query_keywords_pipeline(index_name="DAX", path_to_settings="../settings.yaml")
 indices = PyTickerSymbols().get_all_indices()
 
 trends_df = get_interest_over_time(
@@ -78,9 +76,7 @@ import chart_studio.plotly as cs
 
 timeframe = f'2016-12-14 {datetime.now().strftime("%Y-%m-%d")}'
 date_index = get_query_date_index(timeframe=timeframe)
-df_search_interest = query_googletrends(
-    keyword_list, date_index=date_index, timeframe=timeframe
-)
+df_search_interest = query_googletrends(keyword_list, date_index=date_index, timeframe=timeframe)
 "", df_search_interest.set_index("date").resample("M")
 
 import tsf_plots

--- a/streamlit/0_ps_exploration.py
+++ b/streamlit/0_ps_exploration.py
@@ -7,9 +7,10 @@ import yaml
 import plotly.express as px
 
 import sys
-sys.path.append('../')
-sys.path.append('../src/data')
-sys.path.append('../src/visualization')
+
+sys.path.append("../")
+sys.path.append("../src/data")
+sys.path.append("../src/visualization")
 
 
 from pytickersymbols import PyTickerSymbols
@@ -18,16 +19,20 @@ from src.data.gtrends_extract import get_interest_over_time
 from tsf_plots import set_layout_template
 
 
-esg_df = yq.esg_firm_query_keywords_pipeline(index_name='DAX', path_to_settings='../settings.yaml')
+esg_df = yq.esg_firm_query_keywords_pipeline(
+    index_name="DAX", path_to_settings="../settings.yaml"
+)
 indices = PyTickerSymbols().get_all_indices()
 
-trends_df = get_interest_over_time(keyword_list=esg_df.query_keyword, 
-    filepath='../data/raw/dax_search_interest_020621.csv', 
-    filepath_failed='../data/raw/failed_dax_search_interest_020621.csv')
+trends_df = get_interest_over_time(
+    keyword_list=esg_df.query_keyword,
+    filepath="../data/raw/dax_search_interest_020621.csv",
+    filepath_failed="../data/raw/failed_dax_search_interest_020621.csv",
+)
 
 # '', trends_df
 
-# join esg and gtrends 
+# join esg and gtrends
 # search_interest = pd.read_csv(filepath).set_index('keyword', drop=False)
 # esg_df = esg_df.set_index('query_keyword', drop=False)
 # search_interest.join(esg_df)
@@ -38,71 +43,78 @@ trends_df = get_interest_over_time(keyword_list=esg_df.query_keyword,
 # st.plotly_chart(fig_over_time)
 
 
-
 st.stop()
 
 
-
-
-
-#---------------------------------------------------
+# ---------------------------------------------------
 # INTEREST OVER TIME
-#---------------------------------------------------
+# ---------------------------------------------------
 
 from gtrends_extract import get_interest_over_time
 
-keyword_list = ['abott labor strike', 'CenterPoint Energy greenwashing', 'abott greenwashing', 'abott transparency']
+keyword_list = [
+    "abott labor strike",
+    "CenterPoint Energy greenwashing",
+    "abott greenwashing",
+    "abott transparency",
+]
 
-'', get_interest_over_time(keyword_list=keyword_list, 
-    filepath='../data/raw/gtrend_test.csv', 
-    filepath_failed='../data/raw/gtrend_test_failed.csv', max_retries=1, timeout=5)
+"", get_interest_over_time(
+    keyword_list=keyword_list,
+    filepath="../data/raw/gtrend_test.csv",
+    filepath_failed="../data/raw/gtrend_test_failed.csv",
+    max_retries=1,
+    timeout=5,
+)
 
 
-
-
-#---------------------------------------------------
+# ---------------------------------------------------
 # VISUALS
-#---------------------------------------------------
+# ---------------------------------------------------
 
 from datetime import datetime
 import plotly.express as px
 import chart_studio.plotly as cs
 
-timeframe = f'2016-12-14 {datetime.now().strftime("%Y-%m-%d")}' 
+timeframe = f'2016-12-14 {datetime.now().strftime("%Y-%m-%d")}'
 date_index = get_query_date_index(timeframe=timeframe)
-df_search_interest =  query_googletrends(keyword_list, date_index=date_index, timeframe=timeframe)
-'', df_search_interest.set_index('date').resample('M')
+df_search_interest = query_googletrends(
+    keyword_list, date_index=date_index, timeframe=timeframe
+)
+"", df_search_interest.set_index("date").resample("M")
 
 import tsf_plots
 
+
 def plot_interest_over_time(df):
     """line chart: weekly change of Google trends """
-    fig = px.line(df, x="date", y="search_interest", color="keyword", 
-                    line_shape='spline',
-                  title='Search interest over time', 
-                 labels={
-                         "date": "",
-                         "keyword": "", 
-                         "search_interest": "Search interest"
-                     },
-                  # text = df.keyword
-                 )
-    # fig.update_traces(mode="markers+lines", hovertemplate="%{text}<br>" + "%{y:20.0f}Mio.<br>%{x}<extra></extra>") 
-    
+    fig = px.line(
+        df,
+        x="date",
+        y="search_interest",
+        color="keyword",
+        line_shape="spline",
+        title="Search interest over time",
+        labels={"date": "", "keyword": "", "search_interest": "Search interest"},
+        # text = df.keyword
+    )
+    # fig.update_traces(mode="markers+lines", hovertemplate="%{text}<br>" + "%{y:20.0f}Mio.<br>%{x}<extra></extra>")
+
     # -- customize legend
     fig.update_layout(
         # legend=dict(
         # orientation="v",
         # yanchor="bottom",
         # y=0.9,
-        # xanchor="right", 
-        # x=0.5, 
-        # bgcolor='rgba(0,0,0,0)'), # transparent  
+        # xanchor="right",
+        # x=0.5,
+        # bgcolor='rgba(0,0,0,0)'), # transparent
         hovermode="closest",
     )
     return fig
 
-def deploy_figure(figure, filename):    
+
+def deploy_figure(figure, filename):
     """ Upload graph to chartstudio """
     logging.info(f"Upload {filename} figure to plotly")
     cs.plot(figure, filename=filename)
@@ -111,4 +123,4 @@ def deploy_figure(figure, filename):
 tsf_plots.set_layout_template()
 fig = plot_interest_over_time(df_search_interest)
 st.plotly_chart(fig)
-deploy_figure(figure=fig, filename='gtrends_greenwashing_sf')
+deploy_figure(figure=fig, filename="gtrends_greenwashing_sf")


### PR DESCRIPTION
There are some windows os dependent libs I found in the old `conda_env.yml`, therefore the building of this new conda env export method. 

Usage: Just run `conda_env_export.py` in your esg-codebase env. 

Minor changes: linting. For linting, I recommend we use flake8 and black. 

Pipeline: On-going. Merge optional. Could wait until I finish it. 